### PR TITLE
make user just put value gh_token

### DIFF
--- a/sicat.py
+++ b/sicat.py
@@ -21,7 +21,7 @@ def main():
         print(f"{ConsoleColors.FAIL}[-] Config file not found.{ConsoleColors.ENDC}")
         print(f"{ConsoleColors.GREEN}[*] Creating config file.{ConsoleColors.ENDC}")
         os.makedirs(os.path.dirname(config_path), exist_ok=True)
-        open(config_path, "w").write("{}")
+        open(config_path, "w").write("{\"gh_token\": \"YOUR_GITHUB_ACCESS_TOKEN\"}")
 
     parser = argparse.ArgumentParser(description="SiCat - Vulnerability & Exploit Finder")
     
@@ -271,3 +271,4 @@ SICAT - The Useful {ConsoleColors.RED}Vulnerability{ConsoleColors.ENDC} & {Conso
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
```
cat  ~/.sicat/config.json

{"gh_token": "YOUR_GITHUB_ACCESS_TOKEN"}
```

sample :
```
$ sicat -k "CVE-2025-66478" -gh

    _._     _,-'""`-._
    (,-.`._,'(       |\`-/|   @justakazh
        `-.-' \ )-`( , o o)
            `-    \`_`"'-
SICAT - The Useful Vulnerability & Exploit Finder

[*] Total Keywords to search: 1
 -> CVE-2025-66478

>>> Searching for: CVE-2025-66478 <<<
---------------------------------------------------------------------------
[+] Searching in GitHub Repositories
---------------------------------------------------------------------------
- Title         : Next.js-RSC-RCE-Scanner-CVE-2025-66478
- Description   : A command-line scanner for batch detection of Next.js application versions and
                  determining if they are affected by CVE-2025-66478 vulnerability.
- Repository    : https://github.com/Malayke/Next.js-RSC-RCE-Scanner-CVE-2025-66478

- Title         : CVE-2025-55182
- Description   : RSC/Next.js RCE Vulnerability Detector & PoC Chrome Extension – CVE-2025-55182 &
                  CVE-2025-66478
- Repository    : https://github.com/emredavut/CVE-2025-55182

- Title         : CVE-2025-55182
- Description   : Docker poc lab for CVE-2025-55182 / CVE-2025-66478 (React2Shell) detection and
                  exploitation
- Repository    : https://github.com/l4rm4nd/CVE-2025-55182

- Title         : Quickcheck-CVE-2025-55182-React-and-CVE-2025-66478-Next.js
- Description   : Script to quick check CVE-2025-55182 (React) and CVE-2025-66478 (Next.js)  -
                  Critical unauthenticated RCE vulnerabilities in the React Server Components (RSC)
                  “Flight” protocol.
- Repository    : https://github.com/BankkRoll/Quickcheck-CVE-2025-55182-React-and-CVE-2025-66478-Next.js

- Title         : react2shell-CVE-2025-55182-full-rce-script
- Description   : React2Shell vulnerability (CVE-2025-55182 / CVE-2025-66478)
- Repository    : https://github.com/pax-k/react2shell-CVE-2025-55182-full-rce-script
```